### PR TITLE
Add image optimization chain controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Elevate your media management experience with **sGallery** today.
 - [x] Sortable Positions.
 - [x] Text Fields for File Management.
 - [x] Image Resize and AVIF or WEBP Conversion.
+- [x] Default image optimization with optional sharpening controls.
 - [x] Integration with Custom Modules.
 - [x] **[sLang](https://github.com/Seiger/sLang)** Integration.
 - [x] More than one tab.

--- a/docs/pages/manipulations/index.md
+++ b/docs/pages/manipulations/index.md
@@ -10,3 +10,4 @@ permalink: /manipulations/
 - [Resize]({{site.baseurl}}/manipulations/resize/)
 - [Fit]({{site.baseurl}}/manipulations/fit/)
 - [Crop]({{site.baseurl}}/manipulations/crop/)
+- [Optimization]({{site.baseurl}}/manipulations/optimization/)

--- a/docs/pages/manipulations/optimization.md
+++ b/docs/pages/manipulations/optimization.md
@@ -1,0 +1,32 @@
+---
+layout: page
+title: Image optimization
+description: Optimize processed images and apply optional sharpening in sGallery.
+permalink: /manipulations/optimization/
+---
+
+Processed images are optimized by default when they are rendered through `sGallery::file()`.
+The optimization step runs after resizing, fitting, or cropping, so generated cache files stay as small as possible.
+
+```php
+$image = sGallery::file($gallery->path)->fit('crop', 592, 320);
+```
+
+You can disable optimization for a specific image when the output should be left untouched.
+
+```php
+$image = sGallery::file($gallery->path)
+    ->optimize(false)
+    ->fit('crop', 592, 320);
+```
+
+Use `sharpen()` when a resized or cropped image needs a small clarity boost.
+The accepted value is from `0` to `100`.
+
+```php
+$image = sGallery::file($gallery->path)
+    ->fit('crop', 592, 320)
+    ->sharpen(10);
+```
+
+Optimization and sharpening are included in the generated cache file name, so changing these options creates a separate cached derivative.

--- a/src/Builders/sGalleryBuilder.php
+++ b/src/Builders/sGalleryBuilder.php
@@ -184,6 +184,30 @@ class sGalleryBuilder
     }
 
     /**
+     * Sharpen the processed image after resize/crop transformations.
+     *
+     * @param float $amount Sharpen amount from 0 to 100.
+     * @return $this
+     */
+    public function sharpen(float $amount): self
+    {
+        $this->params['sharpen'] = max(0, min(100, $amount));
+        return $this;
+    }
+
+    /**
+     * Run Spatie image optimizer after the processed image is saved.
+     *
+     * @param bool $optimize Whether to optimize the output image.
+     * @return $this
+     */
+    public function optimize(bool $optimize = true): self
+    {
+        $this->params['optimize'] = $optimize;
+        return $this;
+    }
+
+    /**
      * Set the resize dimensions for the image.
      *
      * @param int $width Width of the image.
@@ -383,6 +407,8 @@ class sGalleryBuilder
                 $ext .= isset($this->params['crop']) ? strtolower($this->params['crop']->value) . '-' : '';
                 $ext .= isset($this->params['focalCenterX']) ? 'focal' . $this->params['focalCenterX'] . '-' . $this->params['focalCenterY'] . '-' : '';
                 $ext .= isset($this->params['w']) ? $this->params['w'] . 'x' . $this->params['h'] : '';
+                $ext .= isset($this->params['sharpen']) && $this->params['sharpen'] > 0 ? '-sh' . $this->params['sharpen'] : '';
+                $ext .= !empty($this->params['optimize']) ? '-opt' : '';
                 $imageName .= (trim($ext) ? '-' . $ext : '') . '.' . $format;
 
                 if (!file_exists(EVO_BASE_PATH . $chacheFile . $imageName)) {
@@ -459,6 +485,14 @@ class sGalleryBuilder
                             $image->manualCrop($this->params['w'], $this->params['h'], $this->params['startX'], $this->params['startY']);
                         } elseif (isset($this->params['w']) && isset($this->params['h'])) {
                             $image->width($this->params['w'])->height($this->params['h']);
+                        }
+
+                        if (isset($this->params['sharpen']) && $this->params['sharpen'] > 0) {
+                            $image->sharpen($this->params['sharpen']);
+                        }
+
+                        if (!empty($this->params['optimize'])) {
+                            $image->optimize();
                         }
 
                         // Handle AVIF format with custom transparency support
@@ -560,6 +594,14 @@ class sGalleryBuilder
                                             $webpImage->width($this->params['w'])->height($this->params['h']);
                                         }
 
+                                        if (isset($this->params['sharpen']) && $this->params['sharpen'] > 0) {
+                                            $webpImage->sharpen($this->params['sharpen']);
+                                        }
+
+                                        if (!empty($this->params['optimize'])) {
+                                            $webpImage->optimize();
+                                        }
+
                                         $webpImage->quality($this->quality)->format('webp')->save($webpPath);
                                         chmod($webpPath, octdec(evo()->getConfig('new_file_permissions', '0666')));
                                     }
@@ -633,6 +675,7 @@ class sGalleryBuilder
     {
         $input = trim(str_replace([EVO_SITE_URL, EVO_BASE_PATH], '', $input), '/');
         $this->file = $input;
+        $this->params = ['optimize' => true];
         return $this;
     }
 


### PR DESCRIPTION
## Summary
- enable optimized cache output by default for `sGallery::file()` image derivatives
- add chainable `optimize()` and `sharpen()` controls
- include optimization and sharpening options in generated cache file names
- document the optimization and sharpening API

## Why
The change keeps default generated image derivatives lightweight while preserving explicit control for cases that need optimization disabled or extra sharpness after resizing/cropping.

## Verification
- Tested first in an installed project vendor copy against PageSpeed image recommendations.
- Ran `git diff --check` for the fork changes.
- PHP/composer checks were not available in the local PATH.