### PR TITLE
fix(sGallery): guard gallery table migrations

### DIFF
--- a/database/migrations/2024_04_18_115416_add_block_column_to_s_galleries.php
+++ b/database/migrations/2024_04_18_115416_add_block_column_to_s_galleries.php
@@ -11,6 +11,10 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (!Schema::hasTable('s_galleries') || Schema::hasColumn('s_galleries', 'block')) {
+            return;
+        }
+
         Schema::table('s_galleries', function (Blueprint $table) {
             $table->string('block', 64)->default('1')->after('parent');
         });
@@ -21,6 +25,10 @@ return new class extends Migration
      */
     public function down(): void
     {
+        if (!Schema::hasTable('s_galleries') || !Schema::hasColumn('s_galleries', 'block')) {
+            return;
+        }
+
         Schema::table('s_galleries', function (Blueprint $table) {
             $table->dropColumn('block');
         });

--- a/database/migrations/2024_05_09_155805_rename_resource_type_column_in_s_galleries.php
+++ b/database/migrations/2024_05_09_155805_rename_resource_type_column_in_s_galleries.php
@@ -11,6 +11,14 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (
+            !Schema::hasTable('s_galleries') ||
+            !Schema::hasColumn('s_galleries', 'resource_type') ||
+            Schema::hasColumn('s_galleries', 'item_type')
+        ) {
+            return;
+        }
+
         Schema::table('s_galleries', function (Blueprint $table) {
             $table->renameColumn('resource_type', 'item_type');
         });
@@ -21,6 +29,14 @@ return new class extends Migration
      */
     public function down(): void
     {
+        if (
+            !Schema::hasTable('s_galleries') ||
+            !Schema::hasColumn('s_galleries', 'item_type') ||
+            Schema::hasColumn('s_galleries', 'resource_type')
+        ) {
+            return;
+        }
+
         Schema::table('s_galleries', function (Blueprint $table) {
             $table->renameColumn('item_type', 'resource_type');
         });


### PR DESCRIPTION
Related issue: Seiger/sCommerce#7

## Summary
- Guard the `block` column migration when `s_galleries` is missing or already has the column.
- Guard the `resource_type` to `item_type` rename migration when the gallery table or expected columns are absent.

## Validation
- `php -l database/migrations/2024_04_18_115416_add_block_column_to_s_galleries.php`
- `php -l database/migrations/2024_05_09_155805_rename_resource_type_column_in_s_galleries.php`
- `git diff --check`

Not run:
- PHPUnit/full package tests, because this checkout has no `vendor`/phpunit setup.

## Risk
Low. The change only skips optional dependency migrations when their target table/columns are absent or already migrated.