### PR TITLE
fix(sGallery): persist upload attributes before insert

### DIFF
--- a/src/Controllers/sGalleryController.php
+++ b/src/Controllers/sGalleryController.php
@@ -129,17 +129,7 @@ class sGalleryController
                 chmod(sGalleryModel::UPLOAD.$this->itemType.'/'.$request->cat.'/'.$filename, $newFileAccessMode);
 
                 // Save in DB
-                $thisFile = sGalleryModel::whereParent($request->cat)
-                    ->whereBlock($this->blockName)
-                    ->whereItemType($this->itemType)
-                    ->whereFile($filename)
-                    ->firstOrCreate();
-                $thisFile->parent = $request->cat;
-                $thisFile->block = $this->blockName;
-                $thisFile->file = $filename;
-                $thisFile->type = $filetype;
-                $thisFile->item_type = $this->itemType;
-                $thisFile->update();
+                $thisFile = $this->saveGalleryFile((int)$request->cat, $filename, $filetype);
 
                 // Create default texts
                 $translate = new sGalleryField();
@@ -205,17 +195,7 @@ class sGalleryController
                 chmod(sGalleryModel::UPLOAD.$this->itemType.'/'.$request->cat.'/'.$filename, $newFileAccessMode);
 
                 // Save in DB
-                $thisFile = sGalleryModel::whereParent($request->cat)
-                    ->whereBlock($this->blockName)
-                    ->whereItemType($this->itemType)
-                    ->whereFile($filename)
-                    ->firstOrCreate();
-                $thisFile->parent = $request->cat;
-                $thisFile->block = $this->blockName;
-                $thisFile->file = $filename;
-                $thisFile->type = $filetype;
-                $thisFile->item_type = $this->itemType;
-                $thisFile->update();
+                $thisFile = $this->saveGalleryFile((int)$request->cat, $filename, $filetype);
 
                 // Create default texts
                 $translate = new sGalleryField();
@@ -260,17 +240,7 @@ class sGalleryController
             preg_match_all($r, $request->input('youtubeLink'), $matches, PREG_SET_ORDER, 0);
             if (isset($matches[0][1])) {
                 // Save in DB
-                $thisFile = sGalleryModel::whereParent($request->cat)
-                    ->whereBlock($this->blockName)
-                    ->whereItemType($this->itemType)
-                    ->whereFile($matches[0][1])
-                    ->firstOrCreate();
-                $thisFile->parent = $request->cat;
-                $thisFile->block = $this->blockName;
-                $thisFile->file = $matches[0][1];
-                $thisFile->type = 'youtube';
-                $thisFile->item_type = $this->itemType;
-                $thisFile->update();
+                $thisFile = $this->saveGalleryFile((int)$request->cat, $matches[0][1], 'youtube');
 
                 // Create default texts
                 $translate = new sGalleryField();
@@ -323,17 +293,7 @@ class sGalleryController
                 }
 
                 // Save in DB
-                $thisFile = sGalleryModel::whereParent($request->cat)
-                    ->whereBlock($this->blockName)
-                    ->whereItemType($this->itemType)
-                    ->whereFile($filename)
-                    ->firstOrCreate();
-                $thisFile->parent = $request->cat;
-                $thisFile->block = $this->blockName;
-                $thisFile->file = $filename;
-                $thisFile->type = $filetype;
-                $thisFile->item_type = $this->itemType;
-                $thisFile->update();
+                $thisFile = $this->saveGalleryFile((int)$request->cat, $filename, $filetype);
 
                 // Create default texts
                 $translate = new sGalleryField();
@@ -444,7 +404,10 @@ class sGalleryController
             $items = $request->list[$key];
 
             foreach ($items as $lang => $item) {
-                $translate = sGalleryField::where('key', $key)->where('lang', $lang)->firstOrCreate();
+                $translate = sGalleryField::where('key', $key)->where('lang', $lang)->first();
+                if (!$translate) {
+                    $translate = new sGalleryField();
+                }
                 $translate->key = $key;
                 $translate->lang = $lang;
                 $translate->alt = ($item['alt'] ?? '');
@@ -459,6 +422,38 @@ class sGalleryController
             $data['message'] = __('sGallery::manager.saved_successfully');
         }
         return response()->json($data);
+    }
+
+    /**
+     * Find or create a gallery file row with all required SQLite fields populated before insert.
+     *
+     * @param int $parent Gallery parent identifier.
+     * @param string $filename Stored file or external media identifier.
+     * @param string $filetype Gallery item type.
+     * @return sGalleryModel The persisted gallery model.
+     *
+     * @since 1.6.0
+     */
+    protected function saveGalleryFile(int $parent, string $filename, string $filetype): sGalleryModel
+    {
+        $gallery = sGalleryModel::whereParent($parent)
+            ->whereBlock($this->blockName)
+            ->whereItemType($this->itemType)
+            ->whereFile($filename)
+            ->first();
+
+        if (!$gallery) {
+            $gallery = new sGalleryModel();
+        }
+
+        $gallery->parent = $parent;
+        $gallery->block = $this->blockName;
+        $gallery->file = $filename;
+        $gallery->type = $filetype;
+        $gallery->item_type = $this->itemType;
+        $gallery->save();
+
+        return $gallery;
     }
 
     /**


### PR DESCRIPTION
Related issue: #17

## Problem
SQLite rejects the gallery upload insert because `firstOrCreate()` is called after query scopes without create attributes. On a new gallery item Eloquent attempts to insert only timestamps, while `parent`, `file`, and the gallery relation fields are required.

## Branch Reason
This is a package-level SQLite compatibility fix for upload/create paths in the sGallery manager controller.

## Change Summary
- Replaced empty `firstOrCreate()` usage in upload paths with an explicit `saveGalleryFile()` helper.
- The helper finds the existing gallery row by parent, block, item type, and file, or creates a new model with all required fields populated before the first insert.
- Updated translation saving to avoid the same empty `firstOrCreate()` pattern for `s_gallery_fields`.

## Landing Surfaces
- `src/Controllers/sGalleryController.php`

## Verification
- `php -l src/Controllers/sGalleryController.php`
- `rg -n "firstOrCreate\(" src\Controllers\sGalleryController.php src\Models database -S`
- `git diff --check`

Not run:
- Full package tests, because this checkout has no `vendor`/phpunit setup.
- Browser upload proof, because no local Evolution CMS SQLite runtime is attached to this package checkout.

## Risk
Low. The change keeps the existing lookup keys and saved attributes, but ensures required values are present before SQLite receives the insert.