### PR TITLE
fix(sGallery): clear loader on upload errors

### DIFF
--- a/views/partials/scripts.blade.php
+++ b/views/partials/scripts.blade.php
@@ -123,19 +123,59 @@
         await fetch('{!!sGallery::route('sGallery.resort', ['cat' => request()->get($typeId), 'itemType' => $itemType, 'block' => $blockName])!!}', {method: 'POST', body: list});
     }
 
+    function hideMainLoader{{$blockId}}() {
+        const mainloader = window.parent.document.getElementById('mainloader');
+        if (mainloader) {
+            mainloader.classList.remove('show');
+        }
+    }
+
+    function showUploadError{{$blockId}}(message) {
+        alertify.alert('@lang('sGallery::manager.file_upload_error')', message || 'Upload failed.');
+    }
+
+    async function readUploadResponse{{$blockId}}(resp) {
+        const contentType = resp.headers.get('content-type') || '';
+        if (contentType.includes('application/json')) {
+            return await resp.json();
+        }
+
+        if (!resp.ok) {
+            throw new Error('HTTP ' + resp.status + ' ' + resp.statusText);
+        }
+
+        throw new Error('Unexpected server response.');
+    }
+
+    async function handleUploadResult{{$blockId}}(data) {
+        if (data.success == 1 && data.preview) {
+            uploadBase{{$blockId}}.insertAdjacentHTML('beforeend', data.preview);
+            await doResorting{{$blockId}}();
+        } else {
+            showUploadError{{$blockId}}(data.error || data.message);
+        }
+    }
+
     async function doUploadFile{{$blockId}}(e) {
         e.preventDefault();
         const files = e.target.files;
         let totalFilesToUpload = files.length;
         // Nothing was selected
         if (totalFilesToUpload === 0) {
+            hideMainLoader{{$blockId}}();
             return;
         }
         let uploads = [];
         for (let i = 0; i < totalFilesToUpload; i++) {
             uploads.push(uploadFile{{$blockId}}(files[i]));
         }
-        await Promise.all(uploads);
+        try {
+            await Promise.all(uploads);
+        } catch (error) {
+            showUploadError{{$blockId}}(error.message);
+        } finally {
+            hideMainLoader{{$blockId}}();
+        }
     }
 
     async function uploadFile{{$blockId}}(f) {
@@ -150,15 +190,9 @@
             method: 'POST',
             body: form
         });
-        let data = await resp.json();
+        let data = await readUploadResponse{{$blockId}}(resp);
         console.log("Uploaded file with name:", f.name);
-        if (data.success == 0) {
-            alertify.alert('@lang('sGallery::manager.file_upload_error')', data.error);
-        } else {
-            uploadBase{{$blockId}}.insertAdjacentHTML('beforeend', data.preview);
-        }
-        window.parent.document.getElementById('mainloader').classList.remove('show');
-        doResorting{{$blockId}}();
+        await handleUploadResult{{$blockId}}(data);
         return data;
     }
 
@@ -168,13 +202,20 @@
         let totalFilesToUpload = files.length;
         // Nothing was selected
         if (totalFilesToUpload === 0) {
+            hideMainLoader{{$blockId}}();
             return;
         }
         let uploads = [];
         for (let i = 0; i < totalFilesToUpload; i++) {
             uploads.push(uploadDownload{{$blockId}}(files[i]));
         }
-        await Promise.all(uploads);
+        try {
+            await Promise.all(uploads);
+        } catch (error) {
+            showUploadError{{$blockId}}(error.message);
+        } finally {
+            hideMainLoader{{$blockId}}();
+        }
     }
 
     async function uploadDownload{{$blockId}}(f) {
@@ -189,15 +230,9 @@
             method: 'POST',
             body: form
         });
-        let data = await resp.json();
+        let data = await readUploadResponse{{$blockId}}(resp);
         console.log("Uploaded file with name:", f.name);
-        if (data.success == 0) {
-            alertify.alert('@lang('sGallery::manager.file_upload_error')', data.error);
-        } else {
-            uploadBase{{$blockId}}.insertAdjacentHTML('beforeend', data.preview);
-        }
-        window.parent.document.getElementById('mainloader').classList.remove('show');
-        doResorting{{$blockId}}();
+        await handleUploadResult{{$blockId}}(data);
         return data;
     }
 
@@ -205,22 +240,23 @@
         console.log("Past EVO library file:", e.target.value);
         let form = new FormData();
         form.append('file', e.target.value);
-        let resp = await fetch('{!!sGallery::route('sGallery.upload-evo-library', [
-                'cat' => request()->get($typeId),
-                'itemType' => $itemType,
-                'block' => $blockName
-            ])!!}', {
-            method: 'POST',
-            body: form
-        });
-        let data = await resp.json();
-        if (data.success == 0) {
-            alertify.alert('@lang('sGallery::manager.file_upload_error')', data.error);
-        } else {
-            uploadBase{{$blockId}}.insertAdjacentHTML('beforeend', data.preview);
+        try {
+            let resp = await fetch('{!!sGallery::route('sGallery.upload-evo-library', [
+                    'cat' => request()->get($typeId),
+                    'itemType' => $itemType,
+                    'block' => $blockName
+                ])!!}', {
+                method: 'POST',
+                body: form
+            });
+            let data = await readUploadResponse{{$blockId}}(resp);
+            await handleUploadResult{{$blockId}}(data);
+            return data;
+        } catch (error) {
+            showUploadError{{$blockId}}(error.message);
+        } finally {
+            hideMainLoader{{$blockId}}();
         }
-        doResorting{{$blockId}}();
-        return data;
     }
 
     // Function to edit image details


### PR DESCRIPTION
Related issue: #20

## Problem
When the upload endpoint returns a 500 HTML error page, the upload JavaScript still calls `resp.json()`. That throws before the loader is cleared, so the manager UI appears to load forever and the user only sees a console JSON parse error.

## Branch Reason
The backend SQLite insert crash from this report is already covered by merged PR #22. This branch hardens the upload UI so failed/non-JSON upload responses do not leave the manager loader stuck.

## Change Summary
- Added shared upload response parsing that detects non-JSON server responses.
- Wrapped image and download uploads in `try/catch/finally` so `mainloader` is always cleared.
- Reused the same upload error handling for EVO library uploads.
- Avoided inserting empty previews when the server returns a validation or failure response.

## Landing Surfaces
- `views/partials/scripts.blade.php`

## Verification
- `git diff --check`
- inspected upload script diff for image upload, download upload, and EVO library upload paths
- confirmed the branch is based on current `upstream/main`, including the merged SQLite insert fix from PR #22

Not run:
- Browser visual proof, because this package checkout has no attached Evolution CMS SQLite manager runtime.

## Risk
Low. The change is limited to upload response handling and loader cleanup; successful JSON upload responses still append the returned preview and trigger resorting.