### PR TITLE
Fix SQLite gallery inserts without empty model creation

### DIFF
--- a/src/Controllers/sGalleryController.php
+++ b/src/Controllers/sGalleryController.php
@@ -404,18 +404,16 @@ class sGalleryController
             $items = $request->list[$key];
 
             foreach ($items as $lang => $item) {
-                $translate = sGalleryField::where('key', $key)->where('lang', $lang)->first();
-                if (!$translate) {
-                    $translate = new sGalleryField();
-                }
-                $translate->key = $key;
-                $translate->lang = $lang;
-                $translate->alt = ($item['alt'] ?? '');
-                $translate->title = ($item['title'] ?? '');
-                $translate->description = ($item['description'] ?? '');
-                $translate->link_text = ($item['link_text'] ?? '');
-                $translate->link = ($item['link'] ?? '');
-                $translate->save();
+                sGalleryField::updateOrCreate(
+                    ['key' => $key, 'lang' => $lang],
+                    [
+                        'alt' => $item['alt'] ?? '',
+                        'title' => $item['title'] ?? '',
+                        'description' => $item['description'] ?? '',
+                        'link_text' => $item['link_text'] ?? '',
+                        'link' => $item['link'] ?? '',
+                    ]
+                );
             }
 
             $data['success'] = 1;
@@ -436,24 +434,15 @@ class sGalleryController
      */
     protected function saveGalleryFile(int $parent, string $filename, string $filetype): sGalleryModel
     {
-        $gallery = sGalleryModel::whereParent($parent)
-            ->whereBlock($this->blockName)
-            ->whereItemType($this->itemType)
-            ->whereFile($filename)
-            ->first();
-
-        if (!$gallery) {
-            $gallery = new sGalleryModel();
-        }
-
-        $gallery->parent = $parent;
-        $gallery->block = $this->blockName;
-        $gallery->file = $filename;
-        $gallery->type = $filetype;
-        $gallery->item_type = $this->itemType;
-        $gallery->save();
-
-        return $gallery;
+        return sGalleryModel::updateOrCreate(
+            [
+                'parent' => $parent,
+                'block' => $this->blockName,
+                'item_type' => $this->itemType,
+                'file' => $filename,
+            ],
+            ['type' => $filetype]
+        );
     }
 
     /**

--- a/src/Models/sGalleryField.php
+++ b/src/Models/sGalleryField.php
@@ -10,5 +10,10 @@ use Illuminate\Database\Eloquent;
  */
 class sGalleryField extends Eloquent\Model
 {
-
+    /**
+     * The attributes that may be mass assigned when translated gallery fields are saved.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = ['key', 'lang', 'alt', 'title', 'description', 'link_text', 'link'];
 }

--- a/src/Models/sGalleryModel.php
+++ b/src/Models/sGalleryModel.php
@@ -54,6 +54,13 @@ class sGalleryModel extends Model
      */
     protected $appends = ['src', 'path'];
 
+    /**
+     * The attributes that may be mass assigned when a gallery row is persisted.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = ['parent', 'block', 'position', 'file', 'type', 'item_type'];
+
     private $cachedFilePath;
 
     /**


### PR DESCRIPTION
## Problem
On strict database drivers, creating a gallery row without required attributes fails before the controller can populate it.

## Branch reason
This branch resolves issue #24 in the MiddleSokilAI fork.

## Change summary
- persist gallery rows with `updateOrCreate()` using their complete identity and required attributes
- persist translated fields with `updateOrCreate()`
- define explicit mass-assignable attributes for gallery and field models

## Landing surfaces
- `sGalleryController`
- `sGalleryModel`
- `sGalleryField`

## Verification
- checked the final diff for whitespace errors
- confirmed no `firstOrCreate()` calls remain under `src/`
- PHP syntax and SQLite runtime verification were unavailable because this environment has no working PHP or WSL runtime

## Remaining open items
- confirm image upload, EVO Library selection, download upload, and translation save against SQLite in an Evolution CMS runtime