### PR TITLE
Fix Windows gallery thumbnail cache paths

### DIFF
--- a/src/Builders/sGalleryBuilder.php
+++ b/src/Builders/sGalleryBuilder.php
@@ -387,14 +387,14 @@ class sGalleryBuilder
 
             if ($this->params !== null && !in_array($extension, ['svg'])) {
                 $imageName = str_replace('.' . pathinfo($this->file, PATHINFO_EXTENSION), '', pathinfo($this->file, PATHINFO_BASENAME));
-                $imagePath = explode(DIRECTORY_SEPARATOR, pathinfo($this->file, PATHINFO_DIRNAME));
+                $imagePath = explode('/', str_replace('\\', '/', pathinfo($this->file, PATHINFO_DIRNAME)));
                 $chacheFile = sGalleryModel::CACHE_DIR;
 
                 foreach ($imagePath as $path) {
                     $chacheFile .= is_numeric($path) ? $path : ($path[0] ?? '');
                 }
 
-                $chacheFile .= DIRECTORY_SEPARATOR;
+                $chacheFile .= '/';
                 $format = $this->params['format'] ?? $this->getSupportedImageFormat();
 
                 // Ensure format is supported (if AVIF was requested but not supported, fallback to WebP)


### PR DESCRIPTION
## Problem
On Windows, thumbnail cache URLs can lose path segments and contain a backslash, which leads to 404 responses.

## Branch reason
This branch resolves issue #25 in the MiddleSokilAI fork.

## Change summary
- normalize source path separators before deriving the cache directory
- use `/` when forming the cache directory used in filesystem and URL paths

## Landing surfaces
- `sGalleryBuilder::getFile()`

## Verification
- checked the final diff for whitespace errors
- confirmed the cache path no longer uses `DIRECTORY_SEPARATOR`
- PHP and a Windows Evolution CMS runtime are unavailable locally

## Remaining open items
- confirm thumbnail generation and serving from a Windows-hosted Evolution CMS installation