### PR TITLE
Move gallery thumbnails to a public cache directory

### DIFF
--- a/src/Models/sGalleryModel.php
+++ b/src/Models/sGalleryModel.php
@@ -29,7 +29,7 @@ class sGalleryModel extends Model
     const UPLOAD = EVO_BASE_PATH . "assets/sgallery/";
     const UPLOADED = EVO_SITE_URL . "assets/sgallery/";
     const NOIMAGE = EVO_SITE_URL . "assets/site/noimage.png";
-    const CACHE_DIR = "assets/cache/";
+    const CACHE_DIR = "assets/sgallery/cache/";
 
     const TYPE_IMAGE = "image";
     const TYPE_VIDEO = "video";


### PR DESCRIPTION
## Problem
Gallery thumbnails are written to the Evolution CMS private cache directory, which the web server intentionally denies to direct requests.

## Branch reason
This branch resolves issue #26 in the MiddleSokilAI fork.

## Change summary
- move the sGallery thumbnail cache from `assets/cache/` to `assets/sgallery/cache/`

## Landing surfaces
- `sGalleryModel::CACHE_DIR`

## Verification
- confirmed the MAUP Evolution CMS checkout denies access in `assets/cache/.htaccess`
- confirmed the cache directory constant has a single sGallery consumer
- checked the final diff for whitespace errors
- PHP and an Evolution CMS runtime are unavailable locally

## Remaining open items
- confirm thumbnail generation and HTTP serving after deployment