### PR TITLE
fix(sGallery): configure image cache directory (#26)

### DIFF
--- a/config/for-cache.gitignore
+++ b/config/for-cache.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!index.html

--- a/config/for-cache.index.html
+++ b/config/for-cache.index.html
@@ -1,0 +1,2 @@
+<h2>Unauthorized access</h2>
+You're not allowed to access file folder

--- a/config/sGallerySettings.php
+++ b/config/sGallerySettings.php
@@ -1,1 +1,4 @@
-<?php return [1];
+<?php return [
+    1,
+    'imageCacheDir' => 'assets/cache/',
+];

--- a/docs/pages/configuration.md
+++ b/docs/pages/configuration.md
@@ -42,3 +42,16 @@ When a resource template requires more than one gallery, the configuration file 
 ```
 
 To visually separate tabs with galleries, a block name is added to the tab header. In this case, it is block 1 and block 2.
+
+## Generated image cache
+
+Use the `imageCacheDir` key to choose the project-relative public directory for generated image derivatives.
+
+```php
+<?php return [
+    1,
+    'imageCacheDir' => 'assets/derived/',
+];
+```
+
+The default is `assets/cache/` for backward compatibility. After changing the directory, run `php artisan vendor:publish --tag=sGallery`. It creates `.gitignore` and `index.html` in the selected directory without changing existing generated images.

--- a/src/Builders/sGalleryBuilder.php
+++ b/src/Builders/sGalleryBuilder.php
@@ -388,7 +388,7 @@ class sGalleryBuilder
             if ($this->params !== null && !in_array($extension, ['svg'])) {
                 $imageName = str_replace('.' . pathinfo($this->file, PATHINFO_EXTENSION), '', pathinfo($this->file, PATHINFO_BASENAME));
                 $imagePath = explode('/', str_replace('\\', '/', pathinfo($this->file, PATHINFO_DIRNAME)));
-                $chacheFile = sGalleryModel::CACHE_DIR;
+                $chacheFile = sGalleryModel::imageCacheDir();
 
                 foreach ($imagePath as $path) {
                     $chacheFile .= is_numeric($path) ? $path : ($path[0] ?? '');

--- a/src/Models/sGalleryModel.php
+++ b/src/Models/sGalleryModel.php
@@ -41,6 +41,24 @@ class sGalleryModel extends Model
     const VIEW_SECTION_DOWNLOADS = "sectionDownloads";
 
     /**
+     * Get the project-relative directory for generated image derivatives.
+     *
+     * @return string
+     *
+     * @since 1.5.1
+     */
+    public static function imageCacheDir(): string
+    {
+        $directory = config('seiger.settings.sGallery.imageCacheDir', self::CACHE_DIR);
+
+        if (!is_string($directory) || trim($directory) === '') {
+            return self::CACHE_DIR;
+        }
+
+        return trim(str_replace('\\', '/', $directory), '/') . '/';
+    }
+
+    /**
      * The table associated with the model.
      *
      * @var string

--- a/src/sGalleryServiceProvider.php
+++ b/src/sGalleryServiceProvider.php
@@ -2,6 +2,7 @@
 
 use EvolutionCMS\ServiceProvider;
 use Event;
+use Seiger\sGallery\Models\sGalleryModel;
 
 class sGalleryServiceProvider extends ServiceProvider
 {
@@ -52,10 +53,14 @@ class sGalleryServiceProvider extends ServiceProvider
      */
     protected function publishResources()
     {
+        $cacheDirectory = rtrim(public_path(sGalleryModel::imageCacheDir()), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+
         $this->publishes([
             dirname(__DIR__) . '/config/sGallerySettings.php' => config_path('seiger/settings/sGallery.php', true),
             dirname(__DIR__) . '/images/noimage.png' => public_path('assets/site/noimage.png'),
             dirname(__DIR__) . '/images/youtube-logo.png' => public_path('assets/site/youtube-logo.png'),
-        ]);
+            dirname(__DIR__) . '/config/for-cache.gitignore' => $cacheDirectory . '.gitignore',
+            dirname(__DIR__) . '/config/for-cache.index.html' => $cacheDirectory . 'index.html',
+        ], 'sGallery');
     }
 }


### PR DESCRIPTION
## Summary
- add an optional `imageCacheDir` setting while preserving `assets/cache/` as the default
- publish package resources, including cache guard files, through the `sGallery` tag
- document how to use a public generated-image directory

Closes #26.